### PR TITLE
Fix ipmi.console.Console docstring

### DIFF
--- a/pyghmi/ipmi/console.py
+++ b/pyghmi/ipmi/console.py
@@ -33,9 +33,7 @@ class Console(object):
     :param bmc: hostname or ip address of BMC
     :param userid: username to use to connect
     :param password: password to connect to the BMC
-    :param iohandler: Either a function to call with bytes, a filehandle to
-                      use for input and output, or a tuple of (input, output)
-                      handles
+    :param iohandler: a function to call with bytes
     :param kg: optional parameter for BMCs configured to require it
     """
 


### PR DESCRIPTION
Taking a handler or tuple of handles was deprecated in 2014.
https://github.com/openstack/pyghmi/commit/e9000313f2cef935edd3eb9a9c57128995b5c0be

Make iohandler docstring match current behavior.

Launchpad Bug #1719665