### PR TITLE
Add 'disk' as an alias of 'hd' ('disk' is used by ipmitool)

### DIFF
--- a/pyghmi/ipmi/command.py
+++ b/pyghmi/ipmi/command.py
@@ -50,6 +50,7 @@ boot_devices = {
     'net': 4,
     'network': 4,
     'pxe': 4,
+    'disk': 8,
     'hd': 8,
     'safe': 0xc,
     'cd': 0x14,


### PR DESCRIPTION
I figured it was worth adding this as an alias since 'ipmitool chassis bootdev disk' is familiar syntax from the systems side of things.