### PR TITLE
fixing NoneType in wc.connect()

### DIFF
--- a/pyghmi/util/webclient.py
+++ b/pyghmi/util/webclient.py
@@ -139,7 +139,7 @@ class SecureHTTPConnection(httplib.HTTPConnection, object):
         self.sock = ssl.wrap_socket(plainsock, cert_reqs=self.cert_reqs)
         # txtcert = self.sock.getpeercert()  # currently not possible
         bincert = self.sock.getpeercert(binary_form=True)
-        if not self._certverify(bincert):
+        if self._certverify is not None and not self._certverify(bincert):
             raise pygexc.UnrecognizedCertificate('Unknown certificate',
                                                  bincert)
 


### PR DESCRIPTION
This PR is to fix this error:

```python
File "pyghmi/ipmi/oem/lenovo/imm.py", line 272, in get_webclient
    wc.connect()
File "pyghmi/util/webclient.py", line 142, in connect
    if not self._certverify(bincert):
TypeError: 'NoneType' object is not callable
```

At this point https://github.com/openstack/pyghmi/blob/master/pyghmi/util/webclient.py#L118
`verifycallback` is `None`, so `self._certverify` is `None` also.


Test code:
```python
from __future__ import print_function
from pyghmi.ipmi.command import Command


def main():
    server = Command('immserver', 'imm_user', '*******')
    inventory = server.get_inventory()
    for i in inventory:
        print(i)

if __name__ == '__main__':
    main()
````